### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ return require('easyswitch').new({
 
 2. Then you can enable/disable that plugin using this command
 ```lua
-:lua require('easyswith').toggle()
+:lua require('easyswitch').toggle()
 ```
 
 # ✨ Keymaps


### PR DESCRIPTION
from: `lua require('easyswith').toggle()`
to     : `lua require('easyswitch').toggle()`